### PR TITLE
Remove highlight.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ Both result in something like:
 <h1>Heading</h1>
 ```
 
+## Syntax highlighting
+
+Syntax highlighting can be done via the 'highlight' option. Here you can pass code through a highlighter (e.g.  [Highlight.js](https://github.com/isagalaev/highlight.js)), for example:
+
+```js
+var hljs = require('highlight.js');
+md('test/fixtures/e.md', {highlight: function highlight(code, lang) {
+  try {
+    try {
+      return hljs.highlight(lang, code).value;
+    } catch (err) {
+      if (!/Unknown language/i.test(err.message)) {
+        throw err;
+      }
+      return hljs.highlightAuto(code).value;
+    }
+  } catch (err) {
+    return code;
+  }
+}
+```
+
 ## Install with [npm](npmjs.org)
 
 ```bash
@@ -108,9 +130,9 @@ To request or contribute a helper to the [github.com/helpers][helpers] org, plea
 ## Author
 
 **Jon Schlinkert**
- 
+
 + [github/helpers](https://github.com/helpers)
-+ [twitter/helpers](http://twitter.com/helpers) 
++ [twitter/helpers](http://twitter.com/helpers)
 
 ## License
 Copyright (c) 2014 Jon Schlinkert  

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@
 'use strict';
 
 var fs = require('fs');
-var hljs = require('highlight.js');
 var Remarkable = require('remarkable');
 var extend = require('extend-shallow');
 
@@ -77,20 +76,6 @@ function markdown(options) {
     langPrefix: 'lang-',
     linkify: true,
     typographer: false,
-    xhtmlOut: false,
-    highlight: function highlight(code, lang) {
-      try {
-        try {
-          return hljs.highlight(lang, code).value;
-        } catch (err) {
-          if (!/Unknown language/i.test(err.message)) {
-            throw err;
-          }
-          return hljs.highlightAuto(code).value;
-        }
-      } catch (err) {
-        return code;
-      }
-    }
+    xhtmlOut: false
   }, options));
 }

--- a/test/fixtures/e.md
+++ b/test/fixtures/e.md
@@ -1,0 +1,6 @@
+# EEE
+
+```
+var message = 'This is an alert';
+alert(message);
+```

--- a/test/test.js
+++ b/test/test.js
@@ -70,3 +70,24 @@ describe('lodash:', function () {
     _.template('<%= _.md("test/fixtures/a.md") %>', {}, settings).should.equal('<h1>AAA</h1>\n<blockquote>\n<p>this is aaa</p>\n</blockquote>\n');
   });
 });
+
+describe('highlight:', function (argument) {
+    var hljs = require('highlight.js');
+    it('should support syntax highlighting', function () {
+        md('test/fixtures/e.md', {highlight: function highlight(code, lang) {
+          try {
+            try {
+              return hljs.highlight(lang, code).value;
+            } catch (err) {
+              if (!/Unknown language/i.test(err.message)) {
+                throw err;
+              }
+              return hljs.highlightAuto(code).value;
+            }
+          } catch (err) {
+            return code;
+          }
+        }
+ }).should.equal('<h1>EEE</h1>\n<pre><code><span class="hljs-keyword">var</span> <span class="hljs-keyword">message</span> = <span class="hljs-string">\'This is an alert\'</span>;\nalert(<span class="hljs-keyword">message</span>);\n</code></pre>\n');
+    });
+});


### PR DESCRIPTION
From issue: https://github.com/helpers/helper-md/issues/1

As this is a large dependency, allow user to pass it in via the
‘highlight’ option.

Have added a test to prove it works by passing in highlight.js manually via 'highlight' option
