### PR TITLE
Support for updated Assemble

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function md(name, opts) {
   extend(opts, opts.hash);
 
   // Support for Assemble, Verb and Template
-  if (this && this.app && this.app.views) {
+  if (this && this.app && typeof this.app.findPartial === 'function') {
     extend(opts, this.options.remarkable);
 
     try {


### PR DESCRIPTION
I'm using Assemble 0.7.6, and this helper was throwing an error. Assemble still passes this conditional test but no longer has the `app.findPartial()` method. I'm not sure if there's a better way to integrate with the newer Assemble, but this works for me and seems like a safer way to check for the expected API.
