### PR TITLE
Bump remarkable

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ent": "^2.2.0",
     "extend-shallow": "^2.0.1",
     "fs-exists-sync": "^0.1.0",
-    "remarkable": "^1.6.2"
+    "remarkable": "^1.7.4"
   },
   "devDependencies": {
     "engine-base": "^0.1.2",


### PR DESCRIPTION
Bump remarkable to get rid of some security vulnerabilities in it.

[Changelog for remarkable](https://github.com/jonschlinkert/remarkable/blob/master/CHANGELOG.md):

1.7.4 / 2019-07-30
------------------

- upgrade argparse (https://github.com/jonschlinkert/remarkable/pull/349)
- prevent a ReDoS vulnerability (#335)
- disallow ascii control characters in URLs (#334)

1.7.0 / 2016-09-27
------------------

- Special thanks to [lemoinem](https://github.com/lemoinem) for adding much needed, and well-written [documentation](docs/)!
- Footnotes are now enabled by default
- Adds support for "passthrough classes", thanks to [matthewmueller](https://github.com/matthewmueller)
- Outlaws data: URLs by default, thanks to [spicyj](https://github.com/spicyj)
- Improves whitespace trimming performance, thanks to [dpkirchner](https://github.com/dpkirchner)
- Image alts are now properly unescaped, thanks to [adam187](https://github.com/adam187)