### PR TITLE
Upgrades Remarkable and highlight.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@
 
 var fs = require('fs');
 var path = require('path');
-var Remarkable = require('remarkable');
+var { Remarkable } = require('remarkable');
+const { linkify } = require('remarkable/linkify');
 var extend = require('extend-shallow');
 var exists = require('fs-exists-sync');
 var ent = require('ent');
@@ -18,7 +19,7 @@ var ent = require('ent');
  * Expose `md` helper
  */
 
-var helper = module.exports = function(name, options, cb) {
+var helper = (module.exports = function (name, options, cb) {
   if (typeof options === 'function') {
     cb = options;
     options = {};
@@ -106,12 +107,23 @@ helper.sync = function(name, options) {
  */
 
 function markdown(options) {
-  return new Remarkable(extend({
-    breaks: false,
-    html: true,
-    langPrefix: 'lang-',
-    linkify: true,
-    typographer: false,
-    xhtmlOut: false
-  }, options));
+  const useLinkify = options.linkify === false ? false : true;
+  delete options.linkify;
+
+  let remarkable = new Remarkable(
+    extend(
+      {
+        breaks: false,
+        html: true,
+        langPrefix: 'lang-',
+        typographer: false,
+        xhtmlOut: false,
+      },
+      options
+    )
+  );
+  if (useLinkify) {
+    remarkable.use(linkify);
+  }
+  return remarkable;
 }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var ent = require('ent');
  * Expose `md` helper
  */
 
-var helper = (module.exports = function (name, options, cb) {
+var helper = module.exports = function (name, options, cb) {
   if (typeof options === 'function') {
     cb = options;
     options = {};

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var ent = require('ent');
  * Expose `md` helper
  */
 
-var helper = module.exports = function (name, options, cb) {
+var helper = module.exports = function(name, options, cb) {
   if (typeof options === 'function') {
     cb = options;
     options = {};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ent": "^2.2.0",
     "extend-shallow": "^2.0.1",
     "fs-exists-sync": "^0.1.0",
-    "remarkable": "^1.6.2"
+    "remarkable": "^2.0.1"
   },
   "devDependencies": {
     "engine-base": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "engine-base": "^0.1.2",
     "gulp-format-md": "^0.1.9",
     "handlebars": "^4.0.5",
-    "highlight.js": "^9.3.0",
+    "highlight.js": "^11.9.0",
     "lodash": "^4.12.0",
     "mocha": "^2.4.5",
     "templates": "^0.17.2"

--- a/test/fixtures/e.md
+++ b/test/fixtures/e.md
@@ -1,6 +1,6 @@
 # EEE
 
-```
+```javascript
 var message = 'This is an alert';
 alert(message);
 ```

--- a/test/test.js
+++ b/test/test.js
@@ -126,11 +126,11 @@ describe('lodash:', function() {
 
 describe('highlight:', function(argument) {
   it('should support syntax highlighting', function() {
-    var actual = md.sync('test/fixtures/e.md', {
-      highlight: function(code, lang) {
+    var actual = md.sync("test/fixtures/e.md", {
+      highlight: function (code, lang) {
         try {
           try {
-            return hljs.highlight(lang, code).value;
+            return hljs.highlight(code, { language: lang }).value;
           } catch (err) {
             if (!/Unknown language/i.test(err.message)) {
               throw err;
@@ -140,8 +140,11 @@ describe('highlight:', function(argument) {
         } catch (err) {
           return code;
         }
-      }
+      },
     });
-    assert.equal(actual, '<h1>EEE</h1>\n<pre><code><span class="hljs-keyword">var</span> <span class="hljs-keyword">message</span> = <span class="hljs-string">\'This is an alert\'</span>;\nalert(<span class="hljs-keyword">message</span>);\n</code></pre>\n');
+    assert.equal(
+      actual,
+      '<h1>EEE</h1>\n<pre><code class="lang-javascript"><span class="hljs-keyword">var</span> message = <span class="hljs-string">\'This is an alert\'</span>;\n<span class="hljs-title function_">alert</span>(message);\n</code></pre>\n'
+    );
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -127,10 +127,10 @@ describe('lodash:', function() {
 describe('highlight:', function(argument) {
   it('should support syntax highlighting', function() {
     var actual = md.sync("test/fixtures/e.md", {
-      highlight: function (code, lang) {
+      highlight: function (code, language) {
         try {
           try {
-            return hljs.highlight(code, { language: lang }).value;
+            return hljs.highlight(code, { language }).value;
           } catch (err) {
             if (!/Unknown language/i.test(err.message)) {
               throw err;


### PR DESCRIPTION
This addresses security concerns with old versions of both of these libraries.

These vulnerabilities were found through an internal tool called "[Snyk](https://snyk.io/)". You can see the vulnerability reports below. Basically the issue is that you need to upgrade your versions of remarkable and highlight.js.

![image](https://github.com/helpers/helper-md/assets/8006971/60ca1efb-bf29-4c58-9bf2-4651da5c41eb)
![image](https://github.com/helpers/helper-md/assets/8006971/8857acae-00d3-4e5b-b566-1b77efbfbc55)
